### PR TITLE
Custom coders

### DIFF
--- a/Sources/Phoenix/Foundation+Phoenix.swift
+++ b/Sources/Phoenix/Foundation+Phoenix.swift
@@ -12,3 +12,25 @@ extension Optional {
         }
     }
 }
+
+extension String {
+    func data(
+        using encoding: String.Encoding,
+        allowLossyConversion: Bool = false
+    ) throws -> Data {
+        let optionalData: Data? = self.data(
+            using: encoding,
+            allowLossyConversion: allowLossyConversion
+        )
+
+        guard let data = optionalData else {
+            throw NSError(
+                domain: "app.shareup.phoenix",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Could not encode '\(self)' into UTF8 bytes"]
+            )
+        }
+
+        return data
+    }
+}

--- a/Sources/Phoenix/IncomingMessage.swift
+++ b/Sources/Phoenix/IncomingMessage.swift
@@ -7,11 +7,11 @@ public struct IncomingMessage {
         case invalidTypeForValue(String, Any?)
     }
 
-    let joinRef: Ref?
-    let ref: Ref?
-    let topic: Topic
-    let event: PhxEvent
-    let payload: Payload
+    public var joinRef: Ref?
+    public var ref: Ref?
+    public var topic: Topic
+    public var event: PhxEvent
+    public var payload: Payload
     
     init(string: String) throws {
         try self.init(data: Data(string.utf8))
@@ -50,7 +50,13 @@ public struct IncomingMessage {
         )
     }
 
-    init(joinRef: Ref? = nil, ref: Ref?, topic: Topic, event: PhxEvent, payload: Payload = [:]) {
+    public init(
+        joinRef: Ref? = nil,
+        ref: Ref?,
+        topic: Topic,
+        event: PhxEvent,
+        payload: Payload = [:]
+    ) {
         self.joinRef = joinRef
         self.ref = ref
         self.topic = topic

--- a/Sources/Phoenix/OutgoingMessage.swift
+++ b/Sources/Phoenix/OutgoingMessage.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-struct OutgoingMessage {
-    let joinRef: Ref?
-    let ref: Ref
-    let topic: Topic
-    let event: PhxEvent
-    let payload: Payload
-    let sentAt: DispatchTime = DispatchTime.now()
+public struct OutgoingMessage {
+    public var joinRef: Ref?
+    public var ref: Ref
+    public var topic: Topic
+    public var event: PhxEvent
+    public var payload: Payload
+    var sentAt: DispatchTime = DispatchTime.now()
     
     enum Error: Swift.Error {
         case missingChannelJoinRef

--- a/Sources/Phoenix/SocketCoder.swift
+++ b/Sources/Phoenix/SocketCoder.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+public typealias OutgoingMessageEncoder = (OutgoingMessage) throws -> Data
+public typealias IncomingMessageDecoder = (Data) throws -> IncomingMessage

--- a/Sources/Phoenix/URLAppendingQueryItems.swift
+++ b/Sources/Phoenix/URLAppendingQueryItems.swift
@@ -47,7 +47,7 @@ extension String {
         var allowedCharacterSet = CharacterSet.alphanumerics
         allowedCharacterSet.insert(charactersIn: allowedCharacters)
 
-        let encoded = addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)
-        return encoded?.replacingOccurrences(of: " ", with: "+")
+        return addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)?
+            .replacingOccurrences(of: " ", with: "+")
     }
 }

--- a/Sources/Phoenix/URLAppendingQueryItems.swift
+++ b/Sources/Phoenix/URLAppendingQueryItems.swift
@@ -47,7 +47,7 @@ extension String {
         var allowedCharacterSet = CharacterSet.alphanumerics
         allowedCharacterSet.insert(charactersIn: allowedCharacters)
 
-        return addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)?
-            .replacingOccurrences(of: " ", with: "+")
+        let encoded = addingPercentEncoding(withAllowedCharacters: allowedCharacterSet)
+        return encoded?.replacingOccurrences(of: " ", with: "+")
     }
 }


### PR DESCRIPTION
This pull request adds the ability for consumers of `Socket` to supply a custom `OutgoingMessageEncoder` and/or `IncomingMessageDecoder`. This matches the behavior of [`phoenix.js`](https://hexdocs.pm/phoenix/js/#socket).