### PR TITLE
Add RawOutgoingMessage and RawIncomingMessage

### DIFF
--- a/Sources/Phoenix/OutgoingMessage.swift
+++ b/Sources/Phoenix/OutgoingMessage.swift
@@ -1,6 +1,18 @@
 import Foundation
 import WebSocketProtocol
 
+public enum RawOutgoingMessage: CustomStringConvertible, Hashable {
+    case binary(Data)
+    case text(String)
+
+    public var description: String {
+        switch self {
+        case let .binary(data): return String(data: data, encoding: .utf8) ?? ""
+        case let .text(text): return text
+        }
+    }
+}
+
 public struct OutgoingMessage {
     public var joinRef: Ref?
     public var ref: Ref
@@ -41,7 +53,7 @@ public struct OutgoingMessage {
         self.payload = push.payload
     }
     
-    public func encoded() throws -> WebSocketMessage {
+    public func encoded() throws -> RawOutgoingMessage {
         let array: [Any?] = [
             joinRef?.rawValue,
             ref.rawValue,

--- a/Sources/Phoenix/SocketCoder.swift
+++ b/Sources/Phoenix/SocketCoder.swift
@@ -1,5 +1,5 @@
 import Foundation
 import WebSocketProtocol
 
-public typealias OutgoingMessageEncoder = (OutgoingMessage) throws -> WebSocketMessage
-public typealias IncomingMessageDecoder = (Data) throws -> IncomingMessage
+public typealias OutgoingMessageEncoder = (OutgoingMessage) throws -> RawOutgoingMessage
+public typealias IncomingMessageDecoder = (RawIncomingMessage) throws -> IncomingMessage

--- a/Sources/Phoenix/SocketError.swift
+++ b/Sources/Phoenix/SocketError.swift
@@ -2,6 +2,5 @@ extension Socket {
     enum Error: Swift.Error {
         case notOpen
         case couldNotSerializeOutgoingMessage(OutgoingMessage)
-        case canNotSendOpenMessage
     }
 }

--- a/Tests/PhoenixTests/SocketTests.swift
+++ b/Tests/PhoenixTests/SocketTests.swift
@@ -778,7 +778,7 @@ class SocketTests: XCTestCase {
         let ex = expectation(description: "Received reply from join")
 
         let encoder: OutgoingMessageEncoder =
-            { (message: OutgoingMessage) throws -> WebSocketMessage in
+            { (message: OutgoingMessage) throws -> RawOutgoingMessage in
                 let array: [Any?] = [
                     message.joinRef?.rawValue,
                     message.ref.rawValue,
@@ -789,8 +789,8 @@ class SocketTests: XCTestCase {
                 return .binary(try JSONSerialization.data(withJSONObject: array, options: []))
             }
 
-        let decoder: IncomingMessageDecoder = { (data: Data) throws -> IncomingMessage in
-            var decoded = try IncomingMessage(data: data)
+        let decoder: IncomingMessageDecoder = { (raw: RawIncomingMessage) throws -> IncomingMessage in
+            var decoded = try IncomingMessage(raw)
             XCTAssertEqual("room:lobbylobbylobby", decoded.topic)
             decoded.topic = "notwhatyouexpected"
             return decoded


### PR DESCRIPTION
This pull request simplifies `OutgoingMessageEncoder` and `IncomingMessageDecoder` by introducing `RawOutgoingMessage` and `RawIncomingMessage`. This prevents the user from accidentally encoding an `WebSocketMessage.open`, and it also makes it clear the user shouldn't try to decode `WebSocketMessage.open`, either. Additionally, this allows custom encoders to determine how the WebSocket should send the message: as a binary or as text.