### PR TITLE
Make OutoingMessage.init() public

### DIFF
--- a/Sources/Phoenix/OutgoingMessage.swift
+++ b/Sources/Phoenix/OutgoingMessage.swift
@@ -25,8 +25,14 @@ public struct OutgoingMessage: CustomDebugStringConvertible {
         case missingChannelJoinRef
     }
     
-    init(ref: Ref, topic: Topic, event: PhxEvent, payload: Payload) {
-        self.joinRef = nil
+    public init(
+        joinRef: Ref? = nil,
+        ref: Ref,
+        topic: Topic,
+        event: PhxEvent,
+        payload: Payload
+    ) {
+        self.joinRef = joinRef
         self.ref = ref
         self.topic = topic
         self.event = event


### PR DESCRIPTION
This pull request makes `OutgoingMessage.init()` public into to make it easier to write network tests in consumers of `phoenix-apple`.