### PR TITLE
Send Channel replies to callbacks only

### DIFF
--- a/Sources/Phoenix/Channel.swift
+++ b/Sources/Phoenix/Channel.swift
@@ -674,9 +674,6 @@ extension Channel {
                       reply.joinRef == joinRef else {
                     return
                 }
-                
-                let subject = self.subject
-                notifySubjectQueue.async { subject.send(.message(reply.message)) }
                 backgroundQueue.async { pushed.callback(reply: reply) }
                 
             case .leaving(let joinRef, let leavingRef):

--- a/Tests/PhoenixTests/SocketTests.swift
+++ b/Tests/PhoenixTests/SocketTests.swift
@@ -447,14 +447,24 @@ class SocketTests: XCTestCase {
             let closeEx = expectation(description: "Should not have closed")
             closeEx.isInverted = true
 
-            let sub = socket.autoconnect().sink(receiveValue:
-                onResults([
-                    .close: { closeEx.fulfill() }
-                ])
-            )
+            var isActive = true
+
+            let sub = socket
+                .autoconnect()
+                .receive(on: DispatchQueue.main)
+                .sink(receiveValue:
+                        onResults([
+                            .close: {
+                                if isActive {
+                                    closeEx.fulfill()
+                                }
+                            }
+                        ])
+                )
             defer { sub.cancel() }
 
             waitForExpectations(timeout: 0.5)
+            isActive = false
         }
     }
 

--- a/Tests/channel-test-coverage.md
+++ b/Tests/channel-test-coverage.md
@@ -222,7 +222,7 @@
 
 - [x] sets up callback for event
 	- https://github.com/phoenixframework/phoenix/blob/118999e0fd8e8192155b787b4b71e3eb3719e7e5/assets/test/channel_test.js#L792
-	- `testCallsCallbackAndNotifiesSubscriberForMessage()`
+	- `testCallsCallbackButDoesNotNotifySubscriberForReply()`
 
 - [x] other event callbacks are ignored
 	- https://github.com/phoenixframework/phoenix/blob/118999e0fd8e8192155b787b4b71e3eb3719e7e5/assets/test/channel_test.js#L805


### PR DESCRIPTION
Channel replies used to be sent to the channel subscriber, too, but this pull request limits them only to the specified callbacks.