### PR TITLE
Allow dynamic WebSocket URLs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shareup/async-extensions.git",
       "state" : {
-        "revision" : "59504194f84b8c66a27503b5fd0640ac9b01f42a",
-        "version" : "4.1.0"
+        "revision" : "f8dec7a227bbbe15fd4df90c787d4c73e91451ba",
+        "version" : "4.2.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shareup/websocket-apple.git",
       "state" : {
-        "revision" : "2fa14629e689ac73e76b949b2216a6ae3f5545c5",
-        "version" : "4.0.1"
+        "revision" : "f409dca92eb61be6dd1183941a8590f9c4459f07",
+        "version" : "4.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/shareup/websocket-apple.git",
-            from: "4.0.1"
+            from: "4.0.2"
         ),
     ],
     targets: [

--- a/Sources/Phoenix/PhoenixChannel.swift
+++ b/Sources/Phoenix/PhoenixChannel.swift
@@ -5,8 +5,8 @@ import JSON
 import os.log
 import Synchronized
 
-private typealias JoinFuture = AsyncExtensions.Future<(Ref, JSON)>
-private typealias LeaveFuture = AsyncExtensions.Future<Void>
+private typealias JoinFuture = AsyncThrowingFuture<(Ref, JSON)>
+private typealias LeaveFuture = AsyncThrowingFuture<Void>
 
 private typealias MessageSubject = PassthroughSubject<Message, Never>
 

--- a/Sources/Phoenix/PhoenixSocket.swift
+++ b/Sources/Phoenix/PhoenixSocket.swift
@@ -30,7 +30,7 @@ final actor PhoenixSocket {
         }
     }
 
-    nonisolated let url: URL
+    nonisolated let url: @Sendable () -> URL
     nonisolated let timeout: UInt64
     nonisolated let heartbeatInterval: UInt64
 
@@ -68,14 +68,14 @@ final actor PhoenixSocket {
     private nonisolated let tasks = TaskStore()
 
     init(
-        url: URL,
+        url: @escaping @Sendable () -> URL,
         timeout: TimeInterval = 10,
         heartbeatInterval: TimeInterval = 30,
         pushEncoder: @escaping PushEncoder = Push.encode,
         messageDecoder: @escaping MessageDecoder = Message.decode,
         makeWebSocket: @escaping MakeWebSocket
     ) {
-        self.url = url.webSocketURLV2
+        self.url = { url().webSocketURLV2 }
         self.timeout = timeout.nanoseconds
         self.heartbeatInterval = heartbeatInterval.nanoseconds
         self.pushEncoder = pushEncoder
@@ -489,7 +489,7 @@ private extension PhoenixSocket {
 
         return try await makeWebSocket(
             id, // id
-            url, // url
+            url(), // url
             .init(), // options
             {}, // onOpen
             { [id] close in

--- a/Sources/Phoenix/PhoenixSocket.swift
+++ b/Sources/Phoenix/PhoenixSocket.swift
@@ -222,16 +222,16 @@ extension PhoenixSocket {
     private func listen() {
         let task = Task { [weak self] in
             guard let self, !Task.isCancelled,
-                  let ws = await self.webSocket
+                  let ws = await webSocket
             else { return }
 
-            let decoder = self.messageDecoder
+            let decoder = messageDecoder
 
             for await msg in ws.messages {
                 do {
                     let message = try decoder(msg)
 
-                    _ = self.pushes.didReceive(message)
+                    _ = pushes.didReceive(message)
 
                     // NOTE: In the case a channel receives
                     // `Event.close`, it will remove itself from
@@ -288,7 +288,7 @@ extension PhoenixSocket {
                 else { throw TimeoutError() }
 
                 let push = Push(topic: "phoenix", event: .heartbeat)
-                let message: Message = try await self.request(push)
+                let message: Message = try await request(push)
 
                 guard !Task.isCancelled
                 else { throw TimeoutError() }
@@ -495,7 +495,7 @@ private extension PhoenixSocket {
             { [id] close in
                 Task { [weak self] in
                     guard let self, !Task.isCancelled else { return }
-                    await self.doCloseFromServer(
+                    await doCloseFromServer(
                         id: id,
                         error: WebSocketError.closeCodeAndReason(
                             close.code, close.reason

--- a/Sources/Phoenix/Socket.swift
+++ b/Sources/Phoenix/Socket.swift
@@ -39,7 +39,7 @@ public struct Socket: Identifiable, Sendable {
 
 public extension Socket {
     static func system(
-        url: URL,
+        url: @escaping @Sendable () -> URL,
         decoder: @escaping MessageDecoder = Message.decode,
         encoder: @escaping PushEncoder = Push.encode,
         maxMessageSize: Int = 5 * 1024 * 1024

--- a/Tests/PhoenixTests/PhoenixChannelTests.swift
+++ b/Tests/PhoenixTests/PhoenixChannelTests.swift
@@ -16,7 +16,7 @@ import XCTest
 // do not apply to our socket or overlap other tests. We skip those tests.
 
 final class PhoenixChannelTests: XCTestCase {
-    private let url = URL(string: "ws://0.0.0.0:4003/socket")!
+    private let url = { @Sendable in URL(string: "ws://0.0.0.0:4003/socket")! }
 
     private var sendSubject: PassthroughSubject<WebSocketMessage, Never>!
     private var receiveSubject: PassthroughSubject<WebSocketMessage, Never>!
@@ -237,7 +237,7 @@ final class PhoenixChannelTests: XCTestCase {
     }
 
     func testJoinsAfterSocketOpenAndJoinDelays() async throws {
-        let openFuture = AsyncExtensions.Future<Void>()
+        let openFuture = AsyncThrowingFuture<Void>()
         let canJoin = Locked(false)
         let didJoin = Locked(false)
 
@@ -299,7 +299,7 @@ final class PhoenixChannelTests: XCTestCase {
     }
 
     func testOpensAfterSocketOpenDelay() async throws {
-        let openFuture = AsyncExtensions.Future<Void>()
+        let openFuture = AsyncThrowingFuture<Void>()
         let canJoin = Locked(false)
         let didJoin = Locked(false)
 
@@ -377,8 +377,8 @@ final class PhoenixChannelTests: XCTestCase {
                     }
                 }
 
-                let didJoin1 = AsyncExtensions.Future<Void>()
-                let didJoin2 = AsyncExtensions.Future<Void>()
+                let didJoin1 = AsyncThrowingFuture<Void>()
+                let didJoin2 = AsyncThrowingFuture<Void>()
 
                 let channel = await self.makeChannel(socket)
 

--- a/Tests/PhoenixTests/PhoenixSocketTests.swift
+++ b/Tests/PhoenixTests/PhoenixSocketTests.swift
@@ -16,7 +16,7 @@ import XCTest
 // do not apply to our socket or overlap other tests. We skip those tests.
 
 final class PhoenixSocketTests: XCTestCase {
-    private let url = URL(string: "ws://0.0.0.0:4003/socket")!
+    private let url = { @Sendable in URL(string: "ws://0.0.0.0:4003/socket")! }
 
     private var sendSubject: PassthroughSubject<WebSocketMessage, Never>!
     private var receiveSubject: PassthroughSubject<WebSocketMessage, Never>!
@@ -42,8 +42,8 @@ final class PhoenixSocketTests: XCTestCase {
         )
 
         let url = socket.url
-        XCTAssertEqual(url.path, "/socket/websocket")
-        XCTAssertEqual(url.query, "vsn=2.0.0")
+        XCTAssertEqual(url().path, "/socket/websocket")
+        XCTAssertEqual(url().query, "vsn=2.0.0")
 
         XCTAssertEqual(10 * NSEC_PER_SEC, socket.timeout)
         XCTAssertEqual(30 * NSEC_PER_SEC, socket.heartbeatInterval)
@@ -58,8 +58,8 @@ final class PhoenixSocketTests: XCTestCase {
         )
 
         let url = socket.url
-        XCTAssertEqual(url.path, "/socket/websocket")
-        XCTAssertEqual(url.query, "vsn=2.0.0")
+        XCTAssertEqual(url().path, "/socket/websocket")
+        XCTAssertEqual(url().query, "vsn=2.0.0")
 
         XCTAssertEqual(12 * NSEC_PER_SEC, socket.timeout)
         XCTAssertEqual(29 * NSEC_PER_SEC, socket.heartbeatInterval)
@@ -587,7 +587,7 @@ final class PhoenixSocketTests: XCTestCase {
             await socket.connect()
             let channel = await socket.channel("abc", rejoinDelay: [0, 0.01])
 
-            let isErrored = AsyncExtensions.Future<Void>()
+            let isErrored = AsyncThrowingFuture<Void>()
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
@@ -726,7 +726,7 @@ private extension PhoenixSocketTests {
 
 private func future(
     timeout: TimeInterval
-) -> AsyncExtensions.Future<Void> {
+) -> AsyncThrowingFuture<Void> {
     .init(timeout: timeout)
 }
 
@@ -735,7 +735,7 @@ private extension PhoenixSocketTests {
         onOpen: @escaping WebSocketOnOpen = {},
         onClose: @escaping WebSocketOnClose = { _ in }
     ) async throws -> WebSocket {
-        try await .system(url: url, onOpen: onOpen, onClose: onClose)
+        try await .system(url: url(), onOpen: onOpen, onClose: onClose)
     }
 
     func fake(

--- a/Tests/PhoenixTests/PushBufferTests.swift
+++ b/Tests/PhoenixTests/PushBufferTests.swift
@@ -155,7 +155,7 @@ final class PushBufferTests: XCTestCase {
 
     func testEarlierTimeoutOverridesLaterTimeout() async throws {
         let didTimeout = Locked(false)
-        let replyFut = Future<Message>()
+        let replyFut = AsyncThrowingFuture<Message>()
 
         let buffer = PushBuffer()
         buffer.resume()


### PR DESCRIPTION
In order to allow the client to use different URLs—which can be useful when passing authorization parameters, for example—when connecting, `Socket.system` now takes a `() -> URL` parameter.