### PR TITLE
Update JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on: push
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-26
     
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
       - name: Test
         run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shareup/json-apple.git",
       "state" : {
-        "revision" : "56349651398f4fc08067f44d4558569182f5ea36",
-        "version" : "1.4.1"
+        "revision" : "05c5b7837c7a56d957889c6c02b509e408120631",
+        "version" : "2.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/shareup/json-apple.git",
-            from: "1.4.1"
+            from: "2.0.0"
         ),
         .package(
             url: "https://github.com/apple/swift-collections.git",


### PR DESCRIPTION
The only meaningful breaking change between JSON 1.4.1 and 2.0.0 is that assigning `nil` through a `JSON` dictionary subscript now stores JSON `null` instead of removing the key. Consumers of this library who relied on the old behavior should now call `removeValue(forKey:)` before passing the payload.